### PR TITLE
add Screensaver::onstart

### DIFF
--- a/src/adapta/components/Screensaver.qml
+++ b/src/adapta/components/Screensaver.qml
@@ -21,8 +21,10 @@ import "style" as Style
 
 Style.Background { 
     id: control
+
+    readonly property bool showOnStart: conf("onstart")
     property real timer: conf("timer.secondes")
-    property real chrono: 0
+    property real chrono: showOnStart ? timer : 0
 
     readonly property bool isRunning: chrono >= timer
     readonly property bool neverVisible: config['enable.primary_screen_only'] == "true" && !primaryScreen

--- a/src/adapta/theme.conf
+++ b/src/adapta/theme.conf
@@ -69,6 +69,7 @@ position.battery="top-right"
 [screensaver]
 timer.secondes=90
 clock.visible=true
+onstart=false
 
 [menu]
 background.color.normal=#222d32

--- a/src/arc/components/Screensaver.qml
+++ b/src/arc/components/Screensaver.qml
@@ -21,8 +21,10 @@ import "style" as Style
 
 Style.Background { 
     id: control
+
+    readonly property bool showOnStart: conf("onstart")
     property real timer: conf("timer.secondes")
-    property real chrono: 0
+    property real chrono: showOnStart ? timer : 0
 
     readonly property bool isRunning: chrono >= timer
     readonly property bool neverVisible: config['enable.primary_screen_only'] == "true" && !primaryScreen

--- a/src/arc/theme.conf
+++ b/src/arc/theme.conf
@@ -69,6 +69,7 @@ position.battery="top-right"
 [screensaver]
 timer.secondes=90
 clock.visible=true
+onstart=false
 
 [menu]
 background.color.normal=#2f343f

--- a/src/goodnight/components/Screensaver.qml
+++ b/src/goodnight/components/Screensaver.qml
@@ -21,8 +21,10 @@ import "style" as Style
 
 Style.Background { 
     id: control
+
+    readonly property bool showOnStart: conf("onstart")
     property real timer: conf("timer.secondes")
-    property real chrono: 0
+    property real chrono: showOnStart ? timer : 0
 
     readonly property bool isRunning: chrono >= timer
     readonly property bool neverVisible: config['enable.primary_screen_only'] == "true" && !primaryScreen

--- a/src/goodnight/theme.conf
+++ b/src/goodnight/theme.conf
@@ -69,6 +69,7 @@ position.battery="top-right"
 [screensaver]
 timer.secondes=90
 clock.visible=true
+onstart=false
 
 [menu]
 background.color.normal=#171122

--- a/src/mount/components/Screensaver.qml
+++ b/src/mount/components/Screensaver.qml
@@ -21,8 +21,10 @@ import "style" as Style
 
 Style.Background { 
     id: control
+
+    readonly property bool showOnStart: conf("onstart")
     property real timer: conf("timer.secondes")
-    property real chrono: 0
+    property real chrono: showOnStart ? timer : 0
 
     readonly property bool isRunning: chrono >= timer
     readonly property bool neverVisible: config['enable.primary_screen_only'] == "true" && !primaryScreen

--- a/src/mount/theme.conf
+++ b/src/mount/theme.conf
@@ -69,6 +69,7 @@ position.button.fullsize="left"
 [screensaver]
 timer.secondes=90
 clock.visible=true
+onstart=false
 
 [menu]
 background.color.normal=#000000

--- a/src/sober/components/Screensaver.qml
+++ b/src/sober/components/Screensaver.qml
@@ -21,8 +21,10 @@ import "style" as Style
 
 Style.Background { 
     id: control
+
+    readonly property bool showOnStart: conf("onstart")
     property real timer: conf("timer.secondes")
-    property real chrono: 0
+    property real chrono: showOnStart ? timer : 0
 
     readonly property bool isRunning: chrono >= timer
     readonly property bool neverVisible: config['enable.primary_screen_only'] == "true" && !primaryScreen

--- a/src/sober/theme.conf
+++ b/src/sober/theme.conf
@@ -69,6 +69,7 @@ position.battery="top-right"
 [screensaver]
 timer.secondes=90
 clock.visible=true
+onstart=false
 
 [menu]
 background.color.normal=#000000

--- a/src/zune/components/Screensaver.qml
+++ b/src/zune/components/Screensaver.qml
@@ -21,8 +21,10 @@ import "style" as Style
 
 Style.Background { 
     id: control
+
+    readonly property bool showOnStart: conf("onstart")
     property real timer: conf("timer.secondes")
-    property real chrono: 0
+    property real chrono: showOnStart ? timer : 0
 
     readonly property bool isRunning: chrono >= timer
     readonly property bool neverVisible: config['enable.primary_screen_only'] == "true" && !primaryScreen

--- a/src/zune/theme.conf
+++ b/src/zune/theme.conf
@@ -69,6 +69,7 @@ position.battery="top-right"
 [screensaver]
 timer.secondes=90
 clock.visible=true
+onstart=false
 
 [menu]
 background.color.normal=#11080e


### PR DESCRIPTION
If onstart is true the Screensaver will be open at start.

This allows a similar behavior to the Login-screen of Win10.